### PR TITLE
override Dataset __setattr__ function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code workspaces
+*.code-workspace

--- a/src/astraeus/dataset.py
+++ b/src/astraeus/dataset.py
@@ -1,0 +1,23 @@
+from typing import Any
+import xarray as xr
+
+
+class Dataset(xr.Dataset):
+	# Need to define this to avoid warning messages
+    __slots__ = ("_dataset",)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Overwrite the setattr function to allow behaviour like Dataset.name = value instead of the usual Dataset['name'] = (coords, value).
+        """
+        try:
+            object.__setattr__(self, name, value)
+        except AttributeError as e:
+            try:
+                if str(e) != "{!r} object has no attribute {!r}".format(
+                    type(self).__name__, name
+                ):
+                    raise e
+                else:
+                    self[name] = (list(self.coords), value)
+            except Exception as e2:
+                raise e2

--- a/src/astraeus/xarrayIO.py
+++ b/src/astraeus/xarrayIO.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+from .dataset import Dataset
 
 
 def writeXR(filename, ds, verbose=True, append=False):
@@ -67,7 +68,7 @@ def readXR(filename, verbose=True):
            (filename.endswith(".h5") == False) and \
            (filename.endswith(".nc") == False):
             filename += ".h5"
-        ds = xr.open_dataset(filename, engine='h5netcdf')
+        ds = Dataset(xr.open_dataset(filename, engine='h5netcdf'))
         if verbose:
             print(f"Finished loading parameters from {filename}")
     except Exception as e:
@@ -257,7 +258,7 @@ def makeDataset(dictionary=None):
     ds: object
         Xarray Dataset
     """
-    ds = xr.Dataset(dictionary)
+    ds = Dataset(dictionary)
     return ds
 
 def concat(datasets, dim='time', data_vars='minimal', coords='minimal', compat='override'):


### PR DESCRIPTION
Following up on our discussion on your Eureka! PR

> I wonder if it is possible to write xarrays using `data.bg = bg_data` by writing a custom `__setattr__` function for the Astraeus objects. It'd save a lot of annoyance and inconsistency between accessing and setting attributes. I don't know why that isn't already possible (maybe there's a good reason they forbid it), but it seems to me like a simple setattr function that converts the `data.bg = bg_data` syntax to the currently required `data['bg'] = bg_data` syntax (programatically so it's not just for one particular attribute) should be pretty easy. I can try fiddling around with that if you're interested.

_Originally posted by @taylorbell57 in https://github.com/kevin218/Eureka/pull/303#discussion_r859111980_

With this commit, it is possible to do `Dataset.name = value` instead of the usual `Dataset['name'] = (coords, value)`.

There may be a good reason that this is currently blocked by xarray, but none immediately came to mind so I thought this would be worth trying.

An alternative to this is to do `Dataset.name.data = value` if your 'name' DataArray was called 'data'. This is already possible with the default xarray Dataset object.