### PR TITLE
Changing == None to is None

### DIFF
--- a/src/astraeus/xarrayIO.py
+++ b/src/astraeus/xarrayIO.py
@@ -107,9 +107,9 @@ def makeFluxLikeDA(flux, time, flux_units, time_units, name=None, y=None, x=None
     da: object
         Xarray DataArray
     """
-    if y == None:
+    if y is None:
         y = np.arange(flux.shape[1])
-    if x == None:
+    if x is None:
         x = np.arange(flux.shape[2])
     da = xr.DataArray(
         flux,


### PR DESCRIPTION
Previously, Astraeus had a comparison to None using `if x == None` which breaks if x is an array as you end up with an element-wise comparison and an array of booleans, the truth of which is ambiguous. This tiny PR fixes that bug