### PR TITLE
Prepare Astraeus for PyPI packaging and distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,8 @@ jobs:
       - name: Test with pytest
         run: |
           pytest tests
+
+      - name: Test building the package
+        run: |
+          pip install build
+          python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = astraeus
-version = 0.3
 author = Kevin B. Stevenson
 author_email = kbstevenson@gmail.com
 description = Exoplanet data reduction I/O with xarray and netCDF support
@@ -25,6 +24,9 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.8
+use_scm_version = True
+setup_requires =
+    setuptools_scm
 install_requires =
     h5py
     xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ project_urls =
     Bug Tracker = https://github.com/kevin218/Astraeus/issues
     Source Code = https://github.com/kevin218/Astraeus
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Astronomy
     Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
-name = Astraeus
+name = astraeus
 version = 0.3
 author = Kevin B. Stevenson
 author_email = kbstevenson@gmail.com
-description = Exoplanet Data Reduction I/O
+description = Exoplanet data reduction I/O with xarray and netCDF support
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = BSD-3-Clause
@@ -13,17 +13,18 @@ project_urls =
     Bug Tracker = https://github.com/kevin218/Astraeus/issues
     Source Code = https://github.com/kevin218/Astraeus
 classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Science/Research
+    Topic :: Scientific/Engineering :: Astronomy
     Programming Language :: Python :: 3
-    License :: OSI Approved :: BSD 3-Clause License
+    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
 
 [options]
 package_dir =
-    =src
+    = src
 packages = find:
-python_requires= >=3.8
-
-# Example of how to add dependencies:
+python_requires = >=3.8
 install_requires =
     h5py
     xarray
@@ -37,12 +38,15 @@ where = src
 
 [options.extras_require]
 docs =
-  sphinx
-  sphinx-automodapi
-  numpydoc
+    sphinx
+    sphinx-automodapi
+    numpydoc
 test =
-  pytest
-  pytest-doctestplus
-  flake8
-  codecov
-  pytest-cov
+    pytest
+    pytest-doctestplus
+    flake8
+    codecov
+    pytest-cov
+dev =
+    build
+    twine


### PR DESCRIPTION
This PR prepares the Astraeus repository for publishing to PyPI by:

- Completing and cleaning the setup.cfg metadata
- Removing the hardcoded version and enabling `setuptools_scm` for automatic versioning from Git tags
- Updating the pyproject.toml file to enable setuptools_scm
- Updating the GitHub Actions CI workflow to test the building of the package after running tests

## How to test the PyPI build locally:

Make sure you are on a clean main branch or a release-tagged commit. Then run:
```
pip install build twine
python -m build
twine check dist/*
```

This will produce valid source and wheel distributions under the `dist/` directory. Because setuptools_scm is now enabled, the version used in the package is determined automatically from the latest Git tag.

If you're preparing the v1.0 release, make sure to run the build *after* the `v1.0` tag is created so that the version is correctly reflected in the package metadata. If the build is run before the tag exists, the version will include a `.devN` suffix instead.

## Optional: Test upload to TestPyPI
```
twine upload --repository testpypi dist/*
```

### To install from TestPyPI:
```
pip install --index-url https://test.pypi.org/simple/ astraeus
```

## When ready to publish to PyPI:
```
twine upload dist/*
```
Let me know if you'd like help configuring release automation moving forward.